### PR TITLE
fix: persistent storage for redis and storage size for media

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ sed -i -e "s;MONGO_STORAGE_SIZE;10Gi;g" \
   ./volumes/**/*.yaml
 sed -i -e "s;POSTGRES_STORAGE_SIZE;10Gi;g" \
   ./volumes/**/*.yaml
+sed -i -e "s;REDIS_STORAGE_SIZE;10Gi;g" \
+  ./volumes/**/*.yaml
 ```
 
 ### Using HostPath (single node deployments ONLY!)
@@ -161,6 +163,8 @@ sed -i -e "s;POSTGRES_VOLUME_PATH;/path/to/my/postgres_data;g" \
   ./volumes/local/postgres-volume-claim.yaml
 sed -i -e "s;MEDIA_VOLUME_PATH;/path/to/my/media_data;g" \
   ./volumes/local/media-volume-claim.yaml
+sed -i -e "s;REDIS_VOLUME_PATH;/path/to/my/redis_data;g" \
+  ./volumes/local/redis-volume-claim.yaml
 ```
 
 To deploy the local volumes for the database, enter the following command:
@@ -173,9 +177,9 @@ uncontrolled behavior!
 
 ### Using NFS
 For multi-nodes deployment, several options make volumes available to the cluster. As an 
-example, NFS claims have been implemented in this repository. Three (3) variables need 
-to be set up in this configuration: `MONGO_VOLUME_PATH`, `POSTGRES_VOLUME_PATH` and 
-`NFS_SERVER_IP`. Here are the commands to configure them:
+example, NFS claims have been implemented in this repository. Five (5) variables need 
+to be set up in this configuration: `MONGO_VOLUME_PATH`, `POSTGRES_VOLUME_PATH`, `REDIS_VOLUME_PATH` 
+`MEDIA_VOLUME_PATH` and `NFS_SERVER_IP`. Here are the commands to configure them:
 ```shell
 # Change the path to the Mongo and PostgreSQL NFS shared folders.
 sed -i -e "s;MONGO_VOLUME_PATH;/path/to/my/mongo_data;g" \
@@ -184,6 +188,8 @@ sed -i -e "s;POSTGRES_VOLUME_PATH;/path/to/my/postgres_data;g" \
   ./volumes/nfs/postgres-volume-claim.yaml
 sed -i -e "s;MEDIA_VOLUME_PATH;/path/to/my/media_data;g" \
   ./volumes/nfs/media-volume-claim.yaml
+sed -i -e "s;REDIS_VOLUME_PATH;/path/to/my/redis_data;g" \
+  ./volumes/nfs/redis-volume-claim.yaml
 # Configure the NFS server IP for both file.
 sed -i -e "s;NFS_SERVER_IP;1.2.3.4;g" ./volumes/nfs/*-volume-claim.yaml
 ```
@@ -199,8 +205,8 @@ Ensure there are no errors with the volume creation by typing:
 ```shell
 kubectl get pvc | grep -i -v bound
 ```
-Volume claims named `cdcs-pvc-mongo` and `cdcs-pvc-postgres` should not appear in the 
-list returned by the command.
+Volume claims named `cdcs-pvc-media`, `cdcs-pvc-mongo`, `cdcs-pvc-redis` 
+and `cdcs-pvc-postgres` should not appear in the list returned by the command.
 
 ## Deployment
 

--- a/k8s/redis-deployment.yaml
+++ b/k8s/redis-deployment.yaml
@@ -24,3 +24,10 @@ spec:
             secretKeyRef:
               name: redis
               key: REDIS_PASS
+        volumeMounts:
+          - mountPath: /data
+            name: redis-storage
+      volumes:
+        - name: redis-storage
+          persistentVolumeClaim:
+            claimName: cdcs-pvc-redis

--- a/volumes/local/redis-volume-claim.yaml
+++ b/volumes/local/redis-volume-claim.yaml
@@ -1,27 +1,27 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: cdcs-pv-media
+  name: cdcs-pv-redis
   labels:
     type: local
 spec:
   capacity:
-    storage: MEDIA_STORAGE_SIZE
+    storage: REDIS_STORAGE_SIZE
   accessModes:
     - ReadWriteMany
   hostPath:
-    path: MEDIA_VOLUME_PATH
+    path: REDIS_VOLUME_PATH
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: cdcs-pvc-media
+  name: cdcs-pvc-redis
 spec:
   storageClassName: ""
   accessModes:
     - ReadWriteMany
-  volumeName: cdcs-pv-media
+  volumeName: cdcs-pv-redis
   resources:
     requests:
-      storage: MEDIA_STORAGE_SIZE
+      storage: REDIS_STORAGE_SIZE
 

--- a/volumes/nfs/media-volume-claim.yaml
+++ b/volumes/nfs/media-volume-claim.yaml
@@ -6,7 +6,7 @@ metadata:
     type: nfs
 spec:
   capacity:
-    storage: 10Gi
+    storage: MEDIA_STORAGE_SIZE
   accessModes:
     - ReadWriteMany
   nfs:
@@ -23,4 +23,4 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 10Gi
+      storage: MEDIA_STORAGE_SIZE

--- a/volumes/nfs/redis-volume-claim.yaml
+++ b/volumes/nfs/redis-volume-claim.yaml
@@ -1,27 +1,26 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: cdcs-pv-media
+  name: cdcs-pv-redis
   labels:
-    type: local
+    type: nfs
 spec:
   capacity:
-    storage: MEDIA_STORAGE_SIZE
+    storage: REDIS_STORAGE_SIZE
   accessModes:
     - ReadWriteMany
-  hostPath:
-    path: MEDIA_VOLUME_PATH
+  nfs:
+    server: NFS_SERVER_IP
+    path: REDIS_VOLUME_PATH
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: cdcs-pvc-media
+  name: cdcs-pvc-redis
 spec:
   storageClassName: ""
   accessModes:
     - ReadWriteMany
-  volumeName: cdcs-pv-media
   resources:
     requests:
-      storage: MEDIA_STORAGE_SIZE
-
+      storage: REDIS_STORAGE_SIZE


### PR DESCRIPTION
- Added PVC for redis
- Replaced hardcoded 10Gi in media PVC by `MEDIA_STORAGE_SIZE`